### PR TITLE
Fix TokenCacheController

### DIFF
--- a/src/Controller/TokenCacheController.php
+++ b/src/Controller/TokenCacheController.php
@@ -7,6 +7,8 @@
 
 namespace Drupal\token\Controller;
 
+use Drupal\Core\Controller\ControllerBase;
+use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
 use Symfony\Cmf\Component\Routing\RouteObjectInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Request;
@@ -14,7 +16,7 @@ use Symfony\Component\HttpFoundation\Request;
 /**
  * Clears cache for tokens.
  */
-class TokenCacheController implements ContainerInjectionInterface{
+class TokenCacheController extends ControllerBase implements ContainerInjectionInterface  {
 
   /**
    * @var \Drupal\Core\Access\CsrfTokenGenerator


### PR DESCRIPTION
It looks like a recent core change is somehow loading controller classes (seems like a performance problem), and is now bailing out on the completely broken & invalid TokenCacheController.

This just fixes the php fatal errors, this will need more work, the CSRF stuff should be handled on the route for example, like the dialog route.
