### PR TITLE
Add license to libraries.yml

### DIFF
--- a/token.libraries.yml
+++ b/token.libraries.yml
@@ -3,7 +3,7 @@ jquery.treeTable:
   version: 2.3.0
   license:
     name: MIT
-    url: https://github.com/jashkenas/backbone/blob/1.1.0/LICENSE
+    url: https://github.com/ludo/jquery-treetable/blob/2.3.0/treeTable/MIT-LICENSE
     gpl-compatible: true
   js:
     js/jquery.treeTable.js: {}

--- a/token.libraries.yml
+++ b/token.libraries.yml
@@ -1,6 +1,10 @@
 jquery.treeTable:
-  remote: 'http://plugins.jquery.com/project/treetable'
+  remote: 'http://plugins.jquery.com/treetable/'
   version: 2.3.0
+  license:
+    name: MIT
+    url: https://github.com/jashkenas/backbone/blob/1.1.0/LICENSE
+    gpl-compatible: true
   js:
     js/jquery.treeTable.js: {}
   css:


### PR DESCRIPTION
Going to admin/config/search/path/patterns fails with the following error 

Twig_Error_Runtime: An exception has been thrown during the rendering of a template ("Missing license information in library definition for 'jquery.treeTable' in modules/token/token.libraries.yml: it has a remote, but no license.") in "core/modules/system/templates/system-config-form.html.twig" at line 17. in Twig_Template->displayWithErrorHandling()

Seems like we now need to add licenses for remote libraries.
