### PR TITLE
Fixing more tests

### DIFF
--- a/src/Tests/TokenBlockTestCase.php
+++ b/src/Tests/TokenBlockTestCase.php
@@ -52,8 +52,9 @@ class TokenBlockTestCase extends TokenTestBase {
       'label' => '[user:name]',
     ));
     $this->drupalGet($block->getSystemPath());
+    $this->drupalPostForm(NULL, array(), t('Save block'));
     // Ensure token validation is working on the block.
-    $this->assertText('The Block title is using the following invalid tokens: [user:name].');
+    $this->assertText('The Title is using the following invalid tokens: [user:name].');
 
     // Create the block for real now with a valid title.
     $settings = $block->get('settings');
@@ -62,9 +63,10 @@ class TokenBlockTestCase extends TokenTestBase {
     $block->save();
 
     // Ensure that tokens are not double-escaped when output as a block title.
+    $this->drupalCreateContentType(array('type' => 'page'));
     $node = $this->drupalCreateNode(array('title' => "Site's first node"));
     $this->drupalGet('node/' . $node->id());
-    // The apostraphe should only be escaped once via \Drupal\Component\Utility\String::checkPlain().
+    // The apostraphe should only be escaped once.
     $this->assertRaw("Site&#039;s first node block title");
   }
 }

--- a/src/Tests/TokenCurrentPageTestCase.php
+++ b/src/Tests/TokenCurrentPageTestCase.php
@@ -36,6 +36,7 @@ class TokenCurrentPageTestCase extends TokenTestBase {
     );
     $this->assertPageTokens('', $tokens);
 
+    $this->drupalCreateContentType(array('type' => 'page'));
     $node = $this->drupalCreateNode(array('title' => 'Node title', 'path' => array('alias' => 'node-alias')));
     $tokens = array(
       '[current-page:title]' => 'Node title',

--- a/token.module
+++ b/token.module
@@ -6,6 +6,7 @@
  */
 
 use Drupal\Component\Utility\String;
+use Drupal\Component\Utility\Unicode;
 use Drupal\Component\Utility\Xss;
 use Drupal\Core\Block\BlockPluginInterface;
 use Drupal\Core\Cache\Cache;
@@ -183,12 +184,12 @@ function token_form_alter(&$form, $form_state, $form_id) {
 /**
  * Implements hook_block_view_alter().
  */
-function token_block_view_alter(&$data, BlockPluginInterface $block) {
+function token_block_view_alter(&$build, BlockPluginInterface $block) {
   $config = $block->getConfiguration();
   $label = $config['label'];
   if ($label != '<none>') {
-    //$block->setConfigurationValue('label', \Drupal::token()->replace($label, array(), array('sanitize' => TRUE)));
-    $data['#configuration']['label'] = \Drupal::token()->replace($label, array(), array('sanitize' => TRUE));
+    // The label is automatically escaped, avoid escaping it twice.
+    $build['#configuration']['label'] = \Drupal::token()->replace($label, array(), array('sanitize' => FALSE));
   }
 }
 
@@ -197,7 +198,6 @@ function token_block_view_alter(&$data, BlockPluginInterface $block) {
  */
 function token_form_block_form_alter(&$form, FormStateInterface $form_state) {
   $form['settings']['label']['#description'] = t('This field supports tokens.');
-  // @todo Figure out why this token validation does not seem to be working here.
   $form['settings']['label']['#element_validate'][] = 'token_element_validate';
   $form['settings']['label'] += array('#token_types' => array());
 }
@@ -606,7 +606,7 @@ function token_get_invalid_tokens($type, $tokens) {
 function token_element_validate(&$element, FormStateInterface $form_state) {
   $value = isset($element['#value']) ? $element['#value'] : $element['#default_value'];
 
-  if (!drupal_strlen($value)) {
+  if (!Unicode::strlen($value)) {
     // Empty value needs no further validation since the element should depend
     // on using the '#required' FAPI property.
     return $element;

--- a/token.tokens.inc
+++ b/token.tokens.inc
@@ -13,6 +13,7 @@ use Drupal\field\Entity\FieldStorageConfig;
 use Drupal\field\FieldStorageConfigInterface;
 use Drupal\field\FieldInstanceConfigInterface;
 use Drupal\system\Entity\Menu;
+use Drupal\user\UserInterface;
 use Symfony\Cmf\Component\Routing\RouteObjectInterface;
 
 /**
@@ -578,7 +579,9 @@ function token_tokens($type, array $tokens, array $data = array(), array $option
       switch ($name) {
         case 'picture':
           // ToDo: Use render arrays. See https://drupal.org/node/2195739
-          $replacements[$original] = _theme('user_picture', array('account' => $account));
+          if ($account instanceof UserInterface && $account->hasField('user_picture')) {
+            $replacements[$original] = _theme('user_picture', array('account' => $account));
+          }
           break;
 
         case 'roles':
@@ -590,7 +593,7 @@ function token_tokens($type, array $tokens, array $data = array(), array $option
     }
 
     // Chained token relationships.
-    if (!empty($account->user_picture) && ($picture_tokens = \Drupal::token()->findWithPrefix($tokens, 'picture'))) {
+    if ($account instanceof UserInterface && $account->hasField('user_picture') && ($picture_tokens = \Drupal::token()->findWithPrefix($tokens, 'picture'))) {
       $replacements += \Drupal::token()->generate('file', $picture_tokens, array('file' => $account->user_picture->entity), $options);
     }
     if ($url_tokens = \Drupal::token()->findWithPrefix($tokens, 'url')) {


### PR DESCRIPTION
- I can't imagine that #element_validate worked in 7.x without a form submission?
- User picture tokens should check for the field and we need to reload the user or it is still there.
- Making sure that node types exist
- block label is now apparently autoescaped, so setting sanitize to FALSE.
