### PR TITLE
Change token requirements to renderable array to allow html tags

### DIFF
--- a/token.install
+++ b/token.install
@@ -31,7 +31,7 @@ function token_requirements($phase = 'runtime') {
         'title' => t('Tokens'),
         'value' => t('Problems detected'),
         'severity' => REQUIREMENT_WARNING,
-        'description' => '<p>' . implode('</p><p>', $token_problems) . '</p>',
+        'description' => array('#markup' => '<p>' . implode('</p><p>', $token_problems) . '</p>'),
       );
     }
   }


### PR DESCRIPTION
When installing the module and looking @ /admin/reports/status, I noticed the HTML inside the token_requirements hook did not display correctly.
Therefore, I changed the attribute of the array to a renderable array, allowing HTML content to be displayed.
