### PR TITLE
Fix single link which now expects Url object

### DIFF
--- a/token.pages.inc
+++ b/token.pages.inc
@@ -6,6 +6,7 @@
  */
 use Drupal\Component\Serialization\Json;
 use Drupal\Core\Utility\Token;
+use Drupal\Core\Url;
 
 /**
  * Theme a link to a token tree either as a regular link or a dialog.
@@ -47,7 +48,7 @@ function theme_token_tree_link($variables) {
    );
   $variables['options']['attributes']['class'][] = 'use-ajax';
 
-  return Drupal::l($variables['text'], 'token.tree', array(), $variables['options']);
+  return Drupal::l($variables['text'], Url::fromRoute('token.tree'), array(), $variables['options']);
 }
 
 /**

--- a/token.pages.inc
+++ b/token.pages.inc
@@ -48,7 +48,7 @@ function theme_token_tree_link($variables) {
    );
   $variables['options']['attributes']['class'][] = 'use-ajax';
 
-  return Drupal::l($variables['text'], Url::fromRoute('token.tree'), array(), $variables['options']);
+  return Drupal::l($variables['text'], Url::fromRoute('token.tree')->setOptions($variables['options']));
 }
 
 /**


### PR DESCRIPTION
As [Switch Drupal::l() and LinkGenerator to expect a Url object](https://www.drupal.org/node/2277103) is in place, current code produces fatal error. In this commit is a simple fix.
