### PR TITLE
Replaced deprecated current_path with the Url controller

### DIFF
--- a/src/Controller/TokenCacheController.php
+++ b/src/Controller/TokenCacheController.php
@@ -9,6 +9,7 @@ namespace Drupal\token\Controller;
 
 use Drupal\Core\Controller\ControllerBase;
 use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
+use Drupal\Core\Url;
 use Symfony\Cmf\Component\Routing\RouteObjectInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Request;
@@ -40,7 +41,8 @@ class TokenCacheController extends ControllerBase implements ContainerInjectionI
   }
 
   public function flush(Request $request) {
-    if (!$request->query->has('token') || ! $this->csrfToken->validate($request->query->get('token'), current_path())) {
+    $url = Url::fromRoute('<current>');
+    if (!$request->query->has('token') || ! $this->csrfToken->validate($request->query->get('token'), $url->toString())) {
       return MENU_NOT_FOUND;
     }
 

--- a/token.module
+++ b/token.module
@@ -13,6 +13,7 @@ use Drupal\Core\Cache\Cache;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Render\Element;
 use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\Core\Url;
 use Drupal\Core\Utility\Token;
 
 /**
@@ -29,7 +30,8 @@ require_once __DIR__ . '/token.tokens.inc';
  */
 function token_help($route_name, RouteMatchInterface $route_match) {
   if ($route_name == 'help.page.token') {
-    if (current_path() != 'admin/help/token') {
+    $url = Url::fromRoute('<current>');
+    if ($url->toString() != 'admin/help/token') {
       // Because system_modules() executes hook_help() for each module to 'test'
       // if they will return anything, but not actually display it, we want to
       // return a TRUE value if this is not actually the help page.


### PR DESCRIPTION
Issue reported on last comment of the port issue on DO: https://www.drupal.org/node/1962358#comment-9448705

current_path() has been removed from Drupal core, here is the change record: https://www.drupal.org/node/2382211

I replaced the only two calls to the function.
