### PR TITLE
Fixes #50, replacing two more deprecated functions from PR #51

### DIFF
--- a/src/Controller/TokenCacheController.php
+++ b/src/Controller/TokenCacheController.php
@@ -9,6 +9,7 @@ namespace Drupal\token\Controller;
 
 use Drupal\Core\Controller\ControllerBase;
 use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
+use Drupal\Core\Url;
 use Symfony\Cmf\Component\Routing\RouteObjectInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Request;
@@ -40,7 +41,8 @@ class TokenCacheController extends ControllerBase implements ContainerInjectionI
   }
 
   public function flush(Request $request) {
-    if (!$request->query->has('token') || ! $this->csrfToken->validate($request->query->get('token'), current_path())) {
+    $url = Url::fromRoute('<current>');
+    if (!$request->query->has('token') || ! $this->csrfToken->validate($request->query->get('token'), $url->toString())) {
       return MENU_NOT_FOUND;
     }
 

--- a/src/Tests/TokenUserTestCase.php
+++ b/src/Tests/TokenUserTestCase.php
@@ -58,9 +58,13 @@ class TokenUserTestCase extends TokenTestBase {
     $this->account = $storage->load($this->account->id());
     $this->assertTrue(!empty($this->account->user_picture->target_id), 'User picture uploaded.');
 
+    $user_picture = array(
+      '#type' => 'user_picture',
+      '#account' => $this->account,
+    );
     $user_tokens = array(
       // ToDo: Use render arrays. See https://drupal.org/node/2195739
-      'picture' => _theme('user_picture', array('account' => $this->account)),
+      'picture' => drupal_render($user_picture),
       'picture:fid' => $this->account->user_picture->target_id,
       'picture:size-raw' => 125,
       'ip-address' => NULL,

--- a/token.module
+++ b/token.module
@@ -1114,7 +1114,7 @@ function token_taxonomy_term_load_all_parents($tid) {
 
   if (!isset($cache[$tid])) {
     $cache[$tid] = array();
-    $parents = taxonomy_term_load_parents_all($tid);
+    $parents = \Drupal::entityManager()->getStorage('taxonomy_term')->loadParentsAll($tid);
     array_shift($parents); // Remove this term from the array.
     $parents = array_reverse($parents);
     foreach ($parents as $term) {

--- a/token.module
+++ b/token.module
@@ -13,6 +13,7 @@ use Drupal\Core\Cache\Cache;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Render\Element;
 use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\Core\Url;
 use Drupal\Core\Utility\Token;
 
 /**
@@ -29,7 +30,8 @@ require_once __DIR__ . '/token.tokens.inc';
  */
 function token_help($route_name, RouteMatchInterface $route_match) {
   if ($route_name == 'help.page.token') {
-    if (current_path() != 'admin/help/token') {
+    $url = Url::fromRoute('<current>');
+    if ($url->toString() != 'admin/help/token') {
       // Because system_modules() executes hook_help() for each module to 'test'
       // if they will return anything, but not actually display it, we want to
       // return a TRUE value if this is not actually the help page.


### PR DESCRIPTION
I've fixed the errors on the two deprecated functions reported by Travis after the PR https://github.com/larowlan/token/pull/51

This should fix the issue with the current_path() https://github.com/larowlan/token/issues/50
