### PR TITLE
Fixing url/path tests when installed in a subfolder

### DIFF
--- a/src/Tests/TokenURLTest.php
+++ b/src/Tests/TokenURLTest.php
@@ -32,19 +32,19 @@ class TokenURLTest extends TokenTestBase {
   }
 
   function testURLTokens() {
-    $host = \Drupal::request()->getHttpHost();
+    $url = new Url('entity.node.canonical', array('node' => 1));
     $tokens = array(
-      'absolute' => "http://{$host}/first-node",
-      'relative' => base_path() . 'first-node',
+      'absolute' => $url->setAbsolute()->toString(),
+      'relative' => $url->setAbsolute(FALSE)->toString(),
       'path' => 'first-node',
-      'brief' => "{$host}/first-node",
+      'brief' => preg_replace(array('!^https?://!', '!/$!'), '', $url->setAbsolute()->toString()),
       'args:value:0' => 'first-node',
       'args:value:1' => NULL,
       'args:value:N' => NULL,
-      'unaliased' => "http://{$host}/node/1",
-      'unaliased:relative' => base_path() . 'node/1',
+      'unaliased' => $url->setAbsolute()->setOption('alias', TRUE)->toString(),
+      'unaliased:relative' => $url->setAbsolute(FALSE)->setOption('alias', TRUE)->toString(),
       'unaliased:path' => 'node/1',
-      'unaliased:brief' => "{$host}/node/1",
+      'unaliased:brief' => preg_replace(array('!^https?://!', '!/$!'), '', $url->setAbsolute()->setOption('alias', TRUE)->toString()),
       'unaliased:args:value:0' => 'node',
       'unaliased:args:value:1' => '1',
       'unaliased:args:value:2' => NULL,

--- a/token.tokens.inc
+++ b/token.tokens.inc
@@ -754,8 +754,7 @@ function token_tokens($type, array $tokens, array $data = array(), array $option
     $url = $data['url'];
     // To retrieve the correct path, modify a copy of the Url object.
     $path_url = clone $url;
-    $path = $path_url->setAbsolute(FALSE)->setOption('fragment', NULL)->toString();
-    $path = ltrim($path, '/');
+    $path = $path_url->setAbsolute(FALSE)->setOption('fragment', NULL)->getInternalPath();
 
     foreach ($tokens as $name => $original) {
       switch ($name) {
@@ -778,7 +777,8 @@ function token_tokens($type, array $tokens, array $data = array(), array $option
           $replacements[$original] = preg_replace(array('!^https?://!', '!/$!'), '', $url->setAbsolute()->toString());
           break;
         case 'unaliased':
-          $replacements[$original] = $url->setAbsolute()->setOption('alias', TRUE)->toString();
+          $unaliased = clone $url;
+          $replacements[$original] = $unaliased->setAbsolute()->setOption('alias', TRUE)->toString();
           break;
         case 'args':
           $value = !($url->getOption('alias')) ? \Drupal::service('path.alias_manager')->getAliasByPath($path, $language_code) : $path;
@@ -791,7 +791,6 @@ function token_tokens($type, array $tokens, array $data = array(), array $option
     // [url:args:*] chained tokens.
     if ($arg_tokens = \Drupal::token()->findWithPrefix($tokens, 'args')) {
       $value = !($url->getOption('alias')) ? \Drupal::service('path.alias_manager')->getAliasByPath($path, $language_code) : $path;
-      $value = ltrim($value, '/');
       $replacements += \Drupal::token()->generate('array', $arg_tokens, array('array' => explode('/', $value)), $options);
     }
 


### PR DESCRIPTION
See https://www.drupal.org/node/1962358#comment-9624575

The tests are failing on d.o due to two reasons:
- Incorrect assumption that toString() with ltrim() of the leading slash is the path. it is not, the url contains the base path. This needs to use the (deprecated) getInternalPath(), which is exactly what 'path' is. Same for args.
- Incorrect hardcoded expectations for URL test about base_path being just /.
